### PR TITLE
feat: GET api for pcp fields. Now patch of fields have same behavior(…

### DIFF
--- a/controllers/Admin/patientManagement/activateInpatient.js
+++ b/controllers/Admin/patientManagement/activateInpatient.js
@@ -35,7 +35,8 @@ const activateInpatient = async (req,res, next) => {
             PCP 
         } = data; 
         const currentUnix = new Date().getTime();
-        if(expiresAt - currentUnix < 0) throw new BadRequest("Expiration date cannot be in the past"); 
+        if(expiresAt - currentUnix < 0) throw new BadRequest("Expiration date cannot be in the past");
+
         const treatmentDurationDays = unixTimeToDays(expiresAt - currentUnix);
 
         // validate patient 
@@ -55,8 +56,12 @@ const activateInpatient = async (req,res, next) => {
 
         if(!patient.dateOfBirth && data.dateOfBirth) patient.set({ dateOfBirth: data.dateOfBirth });
         if(!patient.gender && data.gender) patient.set({gender: data.gender});
-        
-        patient.set({ packages: packages, expiresAt: expiresAt }); 
+
+        patient.set({ 
+            packages: packages,
+            startedAt: currentUnix,
+            expiresAt: expiresAt 
+        }); 
         await patient.save({session}); 
         // ---- 
 

--- a/controllers/Doctor/PCP_Actions/getCurrentField.js
+++ b/controllers/Doctor/PCP_Actions/getCurrentField.js
@@ -18,6 +18,10 @@ const getCurrentCondition = async (req, res, next) => {
             return res.status(StatusCodes.NOT_FOUND).json({ success: false, message: "Patient not found" });
         }
 
+        if (!patient[field]){
+            return res.status(StatusCodes.NOT_FOUND).json({ success: false, message: "Field not found" });
+        }
+
         // send success true and current condition if exisits
         const answer = {success: true};
         answer[field] = patient[field];

--- a/controllers/Doctor/PCP_Actions/getCurrentField.js
+++ b/controllers/Doctor/PCP_Actions/getCurrentField.js
@@ -1,0 +1,32 @@
+import Patient from "../../../db/models/Patient.js";
+import { StatusCodes } from "http-status-codes";
+import joi from "joi"; 
+import validateData from "../../../utils/validateData.js";
+import { mongoIdLength } from "../../../utils/constants.js";
+
+const joiSchema = joi.object({
+    field: joi.string().max(30).required(),
+    patientId: joi.string().min(mongoIdLength).required()
+});
+
+const getCurrentCondition = async (req, res, next) => {
+    try {
+        const { field, patientId } = await validateData(joiSchema, req.params); 
+        const patient = await Patient.findById(patientId);
+
+        if (!patient) {
+            return res.status(StatusCodes.NOT_FOUND).json({ success: false, message: "Patient not found" });
+        }
+
+        // send success true and current condition if exisits
+        const answer = {success: true};
+        answer[field] = patient[field];
+
+        return res.status(StatusCodes.OK).json(answer);
+    } catch (err) {
+        return next(err);
+    }
+};
+
+
+export default getCurrentCondition;

--- a/controllers/Doctor/PCP_Actions/getDocsPatients.js
+++ b/controllers/Doctor/PCP_Actions/getDocsPatients.js
@@ -9,7 +9,10 @@ const getDocsPatients = async(req, res, next) => {
         const docId = req.userId; 
         const doctor = await User.findById(docId);
         if(!doctor || doctor.role !== 'Doctor') throw new NotFound(`Doctor account with this ${docId} not found`);
-        const patients = await Patient.find({ PCP: doctor._id }, { firstName: 1, lastName: 1, });
+        const patients = await Patient.find(
+            { PCP: doctor._id }, { firstName: 1, lastName: 1 }
+        );
+
         const response = {
             success: true, 
             patients

--- a/controllers/Doctor/PCP_Actions/updateComplaints.js
+++ b/controllers/Doctor/PCP_Actions/updateComplaints.js
@@ -6,15 +6,15 @@ import { mongoIdLength } from "../../../utils/constants.js";
 
 
 const joiSchema = joi.object({
-    complaints: joi.string().max(200).required(), 
-    patientId: joi.string().min(mongoIdLength).required()
+    patientId: joi.string().min(mongoIdLength).required(),
+    newText: joi.string().max(200).required()
 })
 
 const updateComplaints = async (req, res, next) => {
     try{
-        const { patientId, complaints } = await validateData(joiSchema, req.body); 
-        await Patient.findByIdAndUpdate(patientId, { $set: { complaints: complaints } }, { projection: { complaints: 1 }});
-        return res.status(StatusCodes.OK).json({success: true, newComplaints: complaints});
+        const { patientId, newText } = await validateData(joiSchema, req.body); 
+        await Patient.findByIdAndUpdate(patientId, { $set: { complaints: newText } }, { projection: { complaints: 1 }});
+        return res.status(StatusCodes.OK).json({success: true, current: newText});
     }catch(err){
         return next(err); 
     }

--- a/controllers/Doctor/PCP_Actions/updateCurrentCondition.js
+++ b/controllers/Doctor/PCP_Actions/updateCurrentCondition.js
@@ -3,16 +3,17 @@ import { StatusCodes } from "http-status-codes";
 import joi from "joi"; 
 import validateData from "../../../utils/validateData.js";
 import { mongoIdLength } from "../../../utils/constants.js";
+
 const joiSchema = joi.object({
     patientId: joi.string().min(mongoIdLength).required(), 
-    currentCondition: joi.string().max(200).required()
+    newText: joi.string().max(200).required()
 })
 
 const updateCurrentCondition = async (req, res, next) => {
     try{
-        const {patientId, currentCondition} = await validateData(joiSchema, req.body); 
-        await Patient.findByIdAndUpdate(patientId, { $set: { currentCondition: currentCondition } }, {projection: {currentCondition: 1}});
-        return res.status(StatusCodes.OK).json({success: true, newCurrentCondition: currentCondition}); 
+        const {patientId, newText} = await validateData(joiSchema, req.body); 
+        await Patient.findByIdAndUpdate(patientId, { $set: { currentCondition: newText } }, {projection: {currentCondition: 1}});
+        return res.status(StatusCodes.OK).json({success: true, current: newText}); 
     }catch(err){
         return next(err); 
     }

--- a/controllers/Doctor/PCP_Actions/updateEpidemicHistory.js
+++ b/controllers/Doctor/PCP_Actions/updateEpidemicHistory.js
@@ -3,18 +3,17 @@ import joi from "joi";
 import validateData from "../../../utils/validateData.js";
 import { StatusCodes } from "http-status-codes";
 import { mongoIdLength } from "../../../utils/constants.js";
-import NotFound from "../../../errorHandlers/NotFound.js";
-import { Unauthorized } from "../../../customErrors/Errors.js";
+
 const joiSchema = joi.object({
-    epidemicHistory: joi.string().max(200).required(), 
-    patientId: joi.string().min(mongoIdLength).required()
+    patientId: joi.string().min(mongoIdLength).required(),
+    newText: joi.string().max(200).required()
 });
 
 const updateEpidemicHistory = async(req, res, next) => {
     try{
-        const {patientId, epidemicHistory} = await validateData(joiSchema, req.body);
-        await Patient.findByIdAndUpdate(patientId, {$set: { epidemicHistory: epidemicHistory }});
-        return res.status(StatusCodes.OK).json({success: true, newEpidemicHistory: epidemicHistory}); 
+        const {patientId, newText} = await validateData(joiSchema, req.body);
+        await Patient.findByIdAndUpdate(patientId, {$set: { epidemicHistory: newText }});
+        return res.status(StatusCodes.OK).json({success: true, current: newText}); 
     }catch(err){
         return next(err); 
     }

--- a/controllers/Doctor/PCP_Actions/updateMainDiagnosis.js
+++ b/controllers/Doctor/PCP_Actions/updateMainDiagnosis.js
@@ -3,16 +3,17 @@ import Patient from "../../../db/models/Patient.js";
 import joi from "joi"; 
 import validateData from "../../../utils/validateData.js";
 import { mongoIdLength } from "../../../utils/constants.js";
+
 const joiSchema = joi.object({
-    diagnosis: joi.string().max(200).required(),
-    patientId: joi.string().min(mongoIdLength).required() 
+    patientId: joi.string().min(mongoIdLength).required(),
+    newText: joi.string().max(200).required()
 });
 
 const updateMainDiagnosis = async (req, res, next) => {
     try{
-        const { patientId, diagnosis } = await validateData(joiSchema, req.body); 
-        await Patient.findByIdAndUpdate(patientId, {$set: { mainDiagnosis: diagnosis }});
-        return res.status(StatusCodes.OK).json({success: true, newDiagnosis: diagnosis}); 
+        const { patientId, newText } = await validateData(joiSchema, req.body); 
+        await Patient.findByIdAndUpdate(patientId, {$set: { mainDiagnosis: newText }});
+        return res.status(StatusCodes.OK).json({success: true, current: newText}); 
     }catch(err){
         return next(err); 
     }

--- a/controllers/Doctor/PCP_Actions/updateMedicalHistory.js
+++ b/controllers/Doctor/PCP_Actions/updateMedicalHistory.js
@@ -5,16 +5,16 @@ import validateData from "../../../utils/validateData.js";
 import { mongoIdLength } from "../../../utils/constants.js";
 
 const joiSchema = joi.object({
-    medicalHistory: joi.string().max(200).required(), 
-    patientId: joi.string().min(mongoIdLength).required()
+    patientId: joi.string().min(mongoIdLength).required(),
+    newText: joi.string().max(200).required()
 });
 
 
 const updateMedicalHistory = async (req, res, next) => {
     try{
-        const { patientId, medicalHistory } = await validateData(joiSchema, req.body);
-        await Patient.findByIdAndUpdate(patientId, { $set: { medicalHistory: medicalHistory } }, { projection: {medicalHistory: 1} });
-        return res.status(StatusCodes.OK).json({success: true, newMedicalHistory: medicalHistory});
+        const { patientId, newText } = await validateData(joiSchema, req.body);
+        await Patient.findByIdAndUpdate(patientId, { $set: { medicalHistory: newText } }, { projection: {medicalHistory: 1} });
+        return res.status(StatusCodes.OK).json({success: true, current: newText});
     }catch(err){
         return next(err); 
     }

--- a/controllers/Doctor/PCP_Actions/updateNeuroCondition.js
+++ b/controllers/Doctor/PCP_Actions/updateNeuroCondition.js
@@ -3,16 +3,17 @@ import { StatusCodes } from "http-status-codes";
 import joi from "joi"; 
 import validateData from "../../../utils/validateData.js";
 import { mongoIdLength } from "../../../utils/constants.js";
+
 const joiSchema = joi.object({
     patientId: joi.string().min(mongoIdLength).required(), 
-    neuroCondition: joi.string().max(200).required()
+    newText: joi.string().max(200).required()
 }); 
 
 const updateNeuroCondition = async (req, res, next) => {
     try{
-        const {patientId, neuroCondition} = await validateData(joiSchema, req.body);
-        await Patient.findByIdAndUpdate(patientId, { $set: { neuroCondition: neuroCondition } }, { projection: {neuroCondition: 1} }); 
-        return res.status(StatusCodes.OK).json({success: true, newNeuroCondition: neuroCondition}); 
+        const {patientId, newText} = await validateData(joiSchema, req.body);
+        await Patient.findByIdAndUpdate(patientId, { $set: { neuroCondition: newText } }, { projection: {neuroCondition: 1} }); 
+        return res.status(StatusCodes.OK).json({success: true, current: newText}); 
     }catch(err){
         return next(err); 
     }

--- a/controllers/Doctor/PCP_Actions/updateStatusLocalis.js
+++ b/controllers/Doctor/PCP_Actions/updateStatusLocalis.js
@@ -6,16 +6,17 @@ import { mongoIdLength } from "../../../utils/constants.js";
 
 const joiSchema = joi.object({
     patientId: joi.string().min(mongoIdLength).required(), 
-    statusLocalis: joi.string().max(200).required()
+    newText: joi.string().max(200).required()
 });
 
 const updateStatusLocalis = async(req, res, next) => {
     try{
-        const {patientId, statusLocalis} = await validateData(joiSchema, req.body);
-        await Patient.findByIdAndUpdate(patientId, { $set: { statusLocalis: statusLocalis } }, { projection: { statusLocalis: 1 } }); 
-        return res.status(StatusCodes.OK).json({success: true}); 
+        const {patientId, newText} = await validateData(joiSchema, req.body);
+        await Patient.findByIdAndUpdate(patientId, { $set: { statusLocalis: newText } }, { projection: { statusLocalis: 1 } }); 
+        return res.status(StatusCodes.OK).json({success: true, current: newText}); 
     }catch(err){
         return next(err); 
     }
 }
+
 export default updateStatusLocalis; 

--- a/controllers/Doctor/notes/createNote.js
+++ b/controllers/Doctor/notes/createNote.js
@@ -8,7 +8,7 @@ import { NotFound } from "../../../customErrors/Errors.js";
 import { mongoIdLength } from "../../../utils/constants.js";
 
 const joiSchema = joi.object({
-    text: joi.string().required().min(5).max(100), 
+    text: joi.string().required().min(5).max(2000), 
     patientId: joi.string().min(mongoIdLength).required()
 });
 

--- a/controllers/Public/Patients/getActiveInpatient.js
+++ b/controllers/Public/Patients/getActiveInpatient.js
@@ -7,6 +7,7 @@ const getActiveInpatient = async (req, res, next) => {
       _id: 1,
       firstName: 1,
       lastName: 1,
+      startedAt: 1,
       expiresAt: 1,
       PCP: 1,
       packages: 1
@@ -19,6 +20,11 @@ const getActiveInpatient = async (req, res, next) => {
 
     // const patients = await Patient.find(query, projection);
     const patients = await Patient.find(query, projection)
+      .populate({
+        path: "PCP",
+        model: "users",
+        select: "_id firstName lastName"
+      })
       .populate({
         path: 'packages', // Reference the 'packages' field
         model: 'MedPackages', // The MedPackage model name

--- a/controllers/Public/Patients/getActiveInpatient.js
+++ b/controllers/Public/Patients/getActiveInpatient.js
@@ -1,0 +1,34 @@
+import Patient from "../../../db/models/Patient.js";
+
+const getActiveInpatient = async (req, res, next) => {
+  try{ 
+    const now = new Date();
+    const projection = {
+      _id: 1,
+      firstName: 1,
+      lastName: 1,
+      expiresAt: 1,
+      PCP: 1,
+      packages: 1
+    };
+
+    const query = {
+      PCP: { $ne: null },
+      expiresAt: { $gte: now }
+    };
+
+    // const patients = await Patient.find(query, projection);
+    const patients = await Patient.find(query, projection)
+      .populate({
+        path: 'packages', // Reference the 'packages' field
+        model: 'MedPackages', // The MedPackage model name
+        select: 'title price' // Select only 'title' and 'price' fields from MedPackage
+      });
+
+    return res.status(200).json({success: true, patients});
+  }catch(err){
+    return next(err);
+  }
+}
+
+export default getActiveInpatient;

--- a/db/models/Patient.js
+++ b/db/models/Patient.js
@@ -38,6 +38,10 @@ const PatientSchema = new mongoose.Schema({
         type: mongoose.Types.ObjectId, 
         default: null
     },
+    startedAt: {
+        type: Number,
+        default: 0
+    },
     lastSeen: {
         type: Number, 
         required: true

--- a/routes/DoctorRouter.js
+++ b/routes/DoctorRouter.js
@@ -10,6 +10,7 @@ import createNote from "../controllers/Doctor/notes/createNote.js";
 import getDocsNotes from "../controllers/Doctor/notes/getDocsNotes.js";
 import deleteNote from "../controllers/Doctor/notes/deleteNote.js";
 import getDocsPatients from "../controllers/Doctor/PCP_Actions/getDocsPatients.js";
+import getCurrentField from "../controllers/Doctor/PCP_Actions/getCurrentField.js";
 import updateCurrentCondition from "../controllers/Doctor/PCP_Actions/updateCurrentCondition.js";
 import updateMedicalHistory from "../controllers/Doctor/PCP_Actions/updateMedicalHistory.js";
 import updateNeuroCondition from "../controllers/Doctor/PCP_Actions/updateNeuroCondition.js";
@@ -40,6 +41,7 @@ router.post("/inpatients/medicalrecords/create", directToService); // creates a 
 
 // PCP ACTIONS 
 router.get("/patients/pcp", getDocsPatients);
+router.get("/patients/pcp/:field/:patientId", getCurrentField);
 router.patch("/patients/pcp/condition", VerifyPCP, updateCurrentCondition);
 router.patch("/patients/pcp/localis", VerifyPCP, updateStatusLocalis);
 router.patch("/patients/pcp/neurocondition", VerifyPCP, updateNeuroCondition);
@@ -47,7 +49,6 @@ router.patch("/patients/pcp/history", VerifyPCP, updateMedicalHistory);
 router.patch("/patients/pcp/epidemichistory", VerifyPCP, updateEpidemicHistory);
 router.patch("/patients/pcp/complaints", VerifyPCP, updateComplaints);
 router.patch("/patients/pcp/diagnosis", VerifyPCP, updateMainDiagnosis);
-
 
 
 //

--- a/routes/PublicRouter.js
+++ b/routes/PublicRouter.js
@@ -11,12 +11,14 @@ import getSingleDoctor from "../controllers/Public/Doctors/getSingleDoctor.js";
 import getDoctors from "../controllers/Public/Doctors/getDoctors.js";
 import getPayments from "../controllers/Public/Payments/getPayments.js";
 import getSinglePayment from "../controllers/Public/Payments/getSinglePayment.js";
+import getActiveInpatient from "../controllers/Public/Patients/getActiveInpatient.js";
 const router = express.Router(); 
 
 // Patients 
 router.get('/patients', getAllPatients);
 router.get("/patients/search", searchPatients);
 router.get("/patients/single/:id", getSinglePatient);
+router.get("/inpatients/active", getActiveInpatient);
 //
 
 // Services 

--- a/utils/unixTimeToDays.js
+++ b/utils/unixTimeToDays.js
@@ -1,7 +1,7 @@
 const unixTimeToDays = (unixTime) => {
     if(unixTime < 0) return; 
-    const secondsInADay = 86400; // 24 hours * 60 minutes * 60 seconds
-    const days = Math.floor(unixTime / secondsInADay);
+    const msInADay = 86400000; // 24 hours * 60 minutes * 60 seconds * 1000 ms
+    const days = Math.floor(unixTime / msInADay);
     return days;
 }
 export default unixTimeToDays;


### PR DESCRIPTION
### GET/POST/PATCH endpoints for PCP

**Added**
- GET requests for pcp fields. It's basically one edpoint that parses field and patientId in querry param. `GET .../:fields/:patientId`
- POST request to redirect inpatient to a regular queue
- GET request to obtain all inpatients with assigned doctor and not expired query
- startedAt field for Patient model to store start date of inpatient

**Changed**

- PATCH requests for pcp fields. Now they all ask for patientId and newText and return success and current fields instead of dynamic name patch. It makes my life easier.
- Max character count for notes from 100 -> 2000
- Fixed `directToService.js` so now it works, it uses mongodb sessions (referenced from `createMedicalRecord.js`)
- Fixed `unixToDays.js` function