### PR TITLE
UNDO inpatient's service , Admin edit, Record diagnosis field and FIXES

### DIFF
--- a/controllers/Auth/Login.js
+++ b/controllers/Auth/Login.js
@@ -35,7 +35,8 @@ const login = async (req, res, next) => {
             accessToken, 
             refreshToken, 
             username, 
-            role: user.role
+            role: user.role,
+            fullname: `${user.firstName} ${user.lastName}`
         });
 }catch(err){
         if(requestNumber > 0){

--- a/controllers/Auth/refreshToken.js
+++ b/controllers/Auth/refreshToken.js
@@ -5,17 +5,29 @@ import verifyRefreshToken from "../../utils/verifyRefreshToken.js";
 import { BadRequest } from "../../customErrors/Errors.js";
 import getAccessToken from "../../utils/getAccessToken.js"; 
 import getRefreshToken from "../../utils/getRefreshToken.js"; 
+
 const joiSchema = joi.object({
     refreshToken: joi.string().min(15).required()
 })
+
 const refreshToken = async(req, res, next) => {
     try{
         const data = await validateData(joiSchema, req.body); 
         const refToken = data['refreshToken']; 
         const load = verifyRefreshToken(refToken);
+
         if(!load['userId']) throw new BadRequest("Invalid token"); 
-        const accessToken = getAccessToken({userId: load['userId'], isAdmin: load['isAdmin']}); 
-        const newRefToken = getRefreshToken({userId: load['userId'], isAdmin: load['isAdmin']});
+        const accessToken = getAccessToken({
+            userId: load['userId'], 
+            isAdmin: load['isAdmin'],
+            isManager: load['isManager']
+        }); 
+        const newRefToken = getRefreshToken({
+            userId: load['userId'],
+            isAdmin: load['isAdmin'],
+            isManager: load['isManager']
+        });
+
         return res.status(StatusCodes.OK).json({success: true, accessToken, refreshToken: newRefToken});
     }catch(err){
         return next(err); 

--- a/controllers/Doctor/PCP_Actions/getDocsPatients.js
+++ b/controllers/Doctor/PCP_Actions/getDocsPatients.js
@@ -8,9 +8,16 @@ const getDocsPatients = async(req, res, next) => {
     try{
         const docId = req.userId; 
         const doctor = await User.findById(docId);
+        const currentUnix = new Date().getTime();
+
         if(!doctor || doctor.role !== 'Doctor') throw new NotFound(`Doctor account with this ${docId} not found`);
         const patients = await Patient.find(
-            { PCP: doctor._id }, { firstName: 1, lastName: 1 }
+            { 
+                PCP: doctor._id,
+                expiresAt: {$gte: currentUnix},
+                packages: {$exists: true, $ne: []}
+            }, 
+            { firstName: 1, lastName: 1 }
         );
 
         const response = {

--- a/controllers/Doctor/medicalRecords/patchMainDiagnosis.js
+++ b/controllers/Doctor/medicalRecords/patchMainDiagnosis.js
@@ -1,0 +1,40 @@
+import { StatusCodes } from "http-status-codes";
+import PatientMedicalRecord from "../../../db/models/PatientMedicalRecords.js";
+import joi from "joi";
+import validateData from "../../../utils/validateData.js";
+
+const joiSchema = joi.object({
+  mainDiagnosis: joi.string().max(200).required(),  // Validate max 200 characters
+  recordId: joi.string().required()  // Ensure the record ID is provided
+});
+
+const updateRecordDiagnosis = async (req, res, next) => {
+  try {
+    // Validate request data using joi
+    const { mainDiagnosis, recordId } = await validateData(joiSchema, req.body);
+
+    // Update the medical record
+    const updatedRecord = await PatientMedicalRecord.findByIdAndUpdate(
+      recordId,
+      { mainDiagnosis: mainDiagnosis },
+      { new: true }  // Return the updated record
+    );
+
+    if (!updatedRecord) {
+      return res.status(StatusCodes.NOT_FOUND).json({
+        success: false,
+        message: "Medical record not found"
+      });
+    }
+
+    return res.status(StatusCodes.OK).json({
+      success: true,
+      message: "Main diagnosis updated successfully"
+    });
+
+  } catch (err) {
+    return next(err);
+  }
+};
+
+export default updateRecordDiagnosis;

--- a/controllers/Doctor/queueFunctionality/getPatientsQueue.js
+++ b/controllers/Doctor/queueFunctionality/getPatientsQueue.js
@@ -14,7 +14,9 @@ import _ from "lodash";
 //             const queue = services[i].currentQueue; 
 //             if(queue.length < 1) continue; 
 //             for(let j = 0; j < queue.length; j++){
-//                 const patientRecord = await PatientMedicalRecord.findById(queue[j], {paymentRecord: 0, updatedAt: 0, __v: 0});  
+//                 const patientRecord = await PatientMedicalRecord.findById(queue[j], 
+//                     {paymentRecord: 0, updatedAt: 0, __v: 0, mainDiagnosis: 0}
+//                 );  
 //                 if(!patientRecord) continue; 
 //                 const recordObj = patientRecord.toObject(); 
 //                 recordObj['serviceTitle'] = services[i].title; 

--- a/controllers/Doctor/queueFunctionality/getPatientsQueue.js
+++ b/controllers/Doctor/queueFunctionality/getPatientsQueue.js
@@ -1,29 +1,85 @@
 import { StatusCodes } from "http-status-codes";
 import Service from "../../../db/models/Service.js"; 
 import PatientMedicalRecord from "../../../db/models/PatientMedicalRecords.js"; 
+import getInterval from "../../../utils/getUnixTodayInterval.js";
 import _ from "lodash";
 
-const getPatientsQueue = async(req, res, next) => {
+// const getPatientsQueue = async(req, res, next) => {
+//     try{
+//         const doctorId = req.userId; 
+//         const services = await Service.find({ providedBy: doctorId, isAvailable: true });
+//         const netQueue = [];
+
+//         for(let i = 0; i < services.length; i++){
+//             const queue = services[i].currentQueue; 
+//             if(queue.length < 1) continue; 
+//             for(let j = 0; j < queue.length; j++){
+//                 const patientRecord = await PatientMedicalRecord.findById(queue[j], {paymentRecord: 0, updatedAt: 0, __v: 0});  
+//                 if(!patientRecord) continue; 
+//                 const recordObj = patientRecord.toObject(); 
+//                 recordObj['serviceTitle'] = services[i].title; 
+//                 netQueue.push(recordObj);   
+//             }
+//         }
+
+//         const sortedQueue = _.sortBy(netQueue, 'createdAt');
+//         return res.status(StatusCodes.OK).json({success: true, queue: sortedQueue}); 
+//     }catch(err){
+//         return next(err); 
+//     }
+// }
+
+const getPatientsQueue = async (req, res, next) => {
     try{
-        const doctorId = req.userId; 
-        const services = await Service.find({ providedBy: doctorId, isAvailable: true });
-        const netQueue = [];
-        for(let i = 0; i < services.length; i++){
-            const queue = services[i].currentQueue; 
-            if(queue.length < 1) continue; 
-            for(let j = 0; j < queue.length; j++){
-                const patientRecord = await PatientMedicalRecord.findById(queue[j], {paymentRecord: 0, updatedAt: 0, __v: 0});  
-                if(!patientRecord) continue; 
-                const recordObj = patientRecord.toObject(); 
-                recordObj['serviceTitle'] = services[i].title; 
-                netQueue.push(recordObj);   
-            }
+        const doctorId = req.userId;
+
+        // Fetch all services provided by the doctor
+        const services = await Service.find({ providedBy: doctorId, isAvailable: true }).select('title currentQueue');
+
+        // Collect all queue IDs into one array
+        const allQueueIds = services.flatMap(service => service.currentQueue).filter(Boolean);
+        if (allQueueIds.length === 0) {
+            return res.status(StatusCodes.OK).json({ success: true, queue: [] });
         }
+
+        // Fetch all patient records in a single query
+        const filter = {_id: { $in: allQueueIds }}        
+        //  for today only by default
+        // NOTE: will be changed in the future
+        const today = getInterval();
+        filter['createdAt'] = {
+            $gte: today.start,
+            $lte: today.end
+        }
+
+        const patientRecords = await PatientMedicalRecord.find(
+            filter,
+            { paymentRecord: 0, updatedAt: 0, __v: 0 }
+        );
+
+        // Create a map of record IDs to their service titles
+        const serviceTitleMap = services.reduce((map, service) => {
+        service.currentQueue.forEach(queueId => {
+            map[queueId] = service.title;
+        });
+        return map;
+        }, {});
+
+        // Attach service title to each patient record
+        const netQueue = patientRecords.map(record => {
+        const recordObj = record.toObject();
+        recordObj['serviceTitle'] = serviceTitleMap[record._id.toString()];
+        return recordObj;
+        });
+
+        // Sort the queue by createdAt
         const sortedQueue = _.sortBy(netQueue, 'createdAt');
-        return res.status(StatusCodes.OK).json({success: true, queue: sortedQueue}); 
-    }catch(err){
-        return next(err); 
+
+        return res.status(StatusCodes.OK).json({ success: true, queue: sortedQueue });
+    } catch (err) {
+      return next(err);
     }
-}
+};
+
 
 export default getPatientsQueue; 

--- a/controllers/Doctor/queueFunctionality/getPatientsQueue.js
+++ b/controllers/Doctor/queueFunctionality/getPatientsQueue.js
@@ -54,7 +54,7 @@ const getPatientsQueue = async (req, res, next) => {
 
         const patientRecords = await PatientMedicalRecord.find(
             filter,
-            { paymentRecord: 0, updatedAt: 0, __v: 0 }
+            { paymentRecord: 0, updatedAt: 0, __v: 0, mainDiagnosis: 0 }
         );
 
         // Create a map of record IDs to their service titles

--- a/controllers/Manager/adminManagement/updateAdmin.js
+++ b/controllers/Manager/adminManagement/updateAdmin.js
@@ -10,32 +10,31 @@ const joiSchema = joi.object({
     lastName: joi.string().optional(),
     phoneNumber: joi.string().pattern(phonePattern).optional(),
     username: joi.string().optional(), 
-    specialty: joi.array().items(joi.string()),
-    doctorId: joi.string().min(mongoIdLength).required()
+    adminId: joi.string().min(mongoIdLength).required()
 });
 
-const updateDoctor = async (req, res, next) => {
+const updateAdmin = async (req, res, next) => {
     try{
         const data = await validateData(joiSchema, req.body); 
         if(data['username']){
             const isTaken = await User.findOne({username: data['username']}); 
             if(isTaken) throw new BadRequest(`Username ${data['username']} is already taken`); 
         }
-        const doctorId = data['doctorId'];
-        delete data['doctorId']; 
-        const updatedDoctor = await User.findOneAndUpdate(
-            {_id: doctorId, role: 'Doctor'},
+        const adminId = data['adminId'];
+        delete data['adminId']; 
+        const updatedAdmin = await User.findOneAndUpdate(
+            {_id: adminId, role: 'Admin'},
             data
         );
-        if(!updatedDoctor) throw new NotFound(`Doctor with ID ${doctorId} not found`);
+        if(!updatedAdmin) throw new NotFound(`Admin with ID ${adminId} not found`);
         const response = {
             success: true, 
-            msg: 'Doctor has been updated', 
-            updatedDoctor
+            msg: 'Admin has been updated', 
+            updatedAdmin
         }
         return res.status(StatusCodes.OK).json(response); 
     }catch(err){
         return next(err); 
     }
 }
-export default updateDoctor; 
+export default updateAdmin; 

--- a/controllers/Manager/patientManagement/undoInpatient.js
+++ b/controllers/Manager/patientManagement/undoInpatient.js
@@ -6,12 +6,13 @@ import joi from "joi";
 
 const joiSchema = joi.object({
   patientId: joi.string().min(mongoIdLength).required(),
+  startedAt: joi.number().required(),
   packages: joi.array().items(joi.string().min(mongoIdLength)).required(),
 })
 
 const undoInpatient = async (req, res, next) => {
   try{
-    const {patientId, packages} = await validateData(joiSchema, req.body);
+    const {patientId, packages, startedAt} = await validateData(joiSchema, req.body);
 
     // clear Patient stationary info
     await Patient.findByIdAndUpdate(patientId, {
@@ -25,7 +26,8 @@ const undoInpatient = async (req, res, next) => {
     const payments = await Payments.find({ 
         patientId: patientId,
         packagesPaid: { $in: packages },
-        isRefunded: false
+        isRefunded: false,
+        createdAt: {$gte: startedAt}
     }).select('_id');
 
     // set all payments of patient to refunded

--- a/controllers/Manager/patientManagement/undoInpatient.js
+++ b/controllers/Manager/patientManagement/undoInpatient.js
@@ -1,0 +1,47 @@
+import Payments from "../../../db/models/Payments.js";
+import Patient from "../../../db/models/Patient.js";
+import validateData from "../../../utils/validateData.js";
+import { mongoIdLength } from "../../../utils/constants.js";
+import joi from "joi"; 
+
+const joiSchema = joi.object({
+  patientId: joi.string().min(mongoIdLength).required(),
+  packages: joi.array().items(joi.string().min(mongoIdLength)).required(),
+})
+
+const undoInpatient = async (req, res, next) => {
+  try{
+    const {patientId, packages} = await validateData(joiSchema, req.body);
+
+    // clear Patient stationary info
+    await Patient.findByIdAndUpdate(patientId, {
+      PCP: null,              
+      expiresAt: 0,           
+      startedAt: 0,          
+      packages: []         
+    });
+
+    // get all the payments of inpatient
+    const payments = await Payments.find({ 
+        patientId: patientId,
+        packagesPaid: { $in: packages },
+        isRefunded: false
+    }).select('_id');
+
+    // set all payments of patient to refunded
+    await Payments.updateMany(
+      {_id: {$in: payments}},
+      {isRefunded: true}
+    )
+    
+    res.status(200).json({
+      success: true,
+      message: "Inpatient service was cancelled successfully.",
+      refundedPayments: payments
+    });
+  } catch(err){
+    return next(err);
+  }
+}
+
+export default undoInpatient;

--- a/controllers/Public/MedicalRecords/getMedicalRecords.js
+++ b/controllers/Public/MedicalRecords/getMedicalRecords.js
@@ -2,7 +2,8 @@ import { StatusCodes } from "http-status-codes";
 import PatientMedicalRecord from "../../../db/models/PatientMedicalRecords.js";
 import joi from "joi"; 
 import validateData from "../../../utils/validateData.js";
-import Payment from "../../../db/models/Payments.js"; 
+import Payment from "../../../db/models/Payments.js";
+import getInterval from "../../../utils/getUnixTodayInterval.js";
 
 const joiSchema = joi.object({
     size: joi.string().regex(/^\d+$/),
@@ -10,7 +11,8 @@ const joiSchema = joi.object({
     sortBy: joi.string().valid('date','price'),
     status: joi.string().valid('completed', 'toRefund', 'refunded', 'queue'),
     skip: joi.string().regex(/^\d+$/)
-})
+});
+
 const getMedicalRecords = async(req, res, next) => {
     try{
         const query = await validateData(joiSchema, req.query); 
@@ -19,9 +21,18 @@ const getMedicalRecords = async(req, res, next) => {
         const skip = Number(query['skip']) > 0 ? Number(query['skip']) : 0; 
         const sortOrder = Number(query['sortOrder']) ? Number(query['sortOrder']): -1; 
         const filter = {}; 
+
         if(query['status']){
             filter['status'] = query['status']
         }
+
+        // add filter to have records for today only
+        const today = getInterval();
+        filter['createdAt'] = {
+            $gte: today.start,
+            $lte: today.end
+        }
+
         const medicalRecords = await PatientMedicalRecord.find(filter)
         .skip(skip) 
         .limit(querySize)

--- a/controllers/Public/MedicalRecords/getMedicalRecords.js
+++ b/controllers/Public/MedicalRecords/getMedicalRecords.js
@@ -10,7 +10,8 @@ const joiSchema = joi.object({
     sortOrder: joi.string().valid('1','-1').regex(/^\d+$/),
     sortBy: joi.string().valid('date','price'),
     status: joi.string().valid('completed', 'toRefund', 'refunded', 'queue'),
-    skip: joi.string().regex(/^\d+$/)
+    skip: joi.string().regex(/^\d+$/),
+    isAdmin: joi.boolean().optional()
 });
 
 const getMedicalRecords = async(req, res, next) => {
@@ -21,9 +22,14 @@ const getMedicalRecords = async(req, res, next) => {
         const skip = Number(query['skip']) > 0 ? Number(query['skip']) : 0; 
         const sortOrder = Number(query['sortOrder']) ? Number(query['sortOrder']): -1; 
         const filter = {}; 
+        let projection;
 
         if(query['status']){
             filter['status'] = query['status']
+        }
+
+        if(query['isAdmin']){
+            projection = {mainDiagnosis: 0}
         }
 
         // add filter to have records for today only
@@ -33,7 +39,7 @@ const getMedicalRecords = async(req, res, next) => {
             $lte: today.end
         }
 
-        const medicalRecords = await PatientMedicalRecord.find(filter)
+        const medicalRecords = await PatientMedicalRecord.find(filter, projection)
         .skip(skip) 
         .limit(querySize)
         .sort({[sortBy]: sortOrder}); 

--- a/controllers/Public/MedicalRecords/getRecordDiagnosis.js
+++ b/controllers/Public/MedicalRecords/getRecordDiagnosis.js
@@ -1,0 +1,29 @@
+import { StatusCodes } from "http-status-codes";
+import PatientMedicalRecord from "../../../db/models/PatientMedicalRecords.js";
+
+const getRecordDiagnosis = async (req, res, next) => {
+  try {
+    // Validate query data using joi
+    const { id } = req.params;
+
+    // Fetch the medical record by ID
+    const data = await PatientMedicalRecord.findById(id, {mainDiagnosis: 1});
+
+    if (!data) {
+      return res.status(StatusCodes.NOT_FOUND).json({
+        success: false,
+        message: "Diagnosis for this record not found"
+      });
+    }
+
+    return res.status(StatusCodes.OK).json({
+      success: true,
+      data
+    });
+
+  } catch (err) {
+    return next(err);
+  }
+};
+
+export default getRecordDiagnosis;

--- a/controllers/Public/Patients/getActiveInpatient.js
+++ b/controllers/Public/Patients/getActiveInpatient.js
@@ -26,9 +26,9 @@ const getActiveInpatient = async (req, res, next) => {
         select: "_id firstName lastName"
       })
       .populate({
-        path: 'packages', // Reference the 'packages' field
-        model: 'MedPackages', // The MedPackage model name
-        select: 'title price' // Select only 'title' and 'price' fields from MedPackage
+        path: 'packages', 
+        model: 'MedPackages', 
+        select: '_id title price'
       });
 
     return res.status(200).json({success: true, patients});

--- a/controllers/Public/Patients/getActiveInpatient.js
+++ b/controllers/Public/Patients/getActiveInpatient.js
@@ -14,7 +14,6 @@ const getActiveInpatient = async (req, res, next) => {
     };
 
     const query = {
-      PCP: { $ne: null },
       expiresAt: { $gte: now }
     };
 

--- a/db/models/Patient.js
+++ b/db/models/Patient.js
@@ -19,7 +19,7 @@ const PatientSchema = new mongoose.Schema({
         match: phonePattern,
     },
     dateOfBirth: {
-        type: String, 
+        type: Number, 
     },
     uniqueId: {
         type: String,

--- a/db/models/PatientMedicalRecords.js
+++ b/db/models/PatientMedicalRecords.js
@@ -44,6 +44,9 @@ const Schema = new mongoose.Schema({
     queueNum: {
         type: Number, 
         required: true
+    },
+    mainDiagnosis: {
+        type: String
     }
 }, {timestamps: true})
 

--- a/middleware/AuthManager.js
+++ b/middleware/AuthManager.js
@@ -1,4 +1,4 @@
-import jwt, { decode } from "jsonwebtoken"; 
+import jwt from "jsonwebtoken"; 
 import { Unauthorized } from "../customErrors/Errors.js";
 import ErrorHandler from '../errorHandlers/ErrorHandler.js'; 
 import { StatusCodes } from 'http-status-codes';

--- a/routes/DoctorRouter.js
+++ b/routes/DoctorRouter.js
@@ -18,6 +18,7 @@ import updateStatusLocalis from "../controllers/Doctor/PCP_Actions/updateStatusL
 import updateMainDiagnosis from "../controllers/Doctor/PCP_Actions/updateMainDiagnosis.js";
 import updateEpidemicHistory from "../controllers/Doctor/PCP_Actions/updateEpidemicHistory.js";
 import updateComplaints from "../controllers/Doctor/PCP_Actions/updateComplaints.js";
+import updateRecordDiagnosis from "../controllers/Doctor/medicalRecords/patchMainDiagnosis.js";
 // NOTES 
 router.get('/notes/all/:id', getAllNotes);
 router.get('/notes/specific/:id', getDocsNotes); 
@@ -32,6 +33,7 @@ router.get("/patients/queue", getPatientsQueue);
 // Med Records 
 router.patch("/medicalrecords/complete/:id", completeRecord); // complete med-record
 router.patch("/medicalrecords/refund/:id", redirectForRefund); // redirect for a refund 
+router.patch('/medicalrecords/diagnosis', updateRecordDiagnosis); // update diagnosis linked to med record
 
 
 // Inpatients  

--- a/routes/ManagerRouter.js
+++ b/routes/ManagerRouter.js
@@ -14,6 +14,7 @@ import updatePackage from "../controllers/Manager/packageManagement/updatePackag
 import addPkgService from '../controllers/Manager/packageManagement/addPkgService.js';
 import removePkgService from "../controllers/Manager/packageManagement/removePkgService.js";
 import updateDoctor from "../controllers/Manager/doctorManagement/updateDoctor.js"; 
+import undoInpatient from "../controllers/Manager/patientManagement/undoInpatient.js";
 const router = express.Router(); 
 
 // Create admin account 
@@ -42,5 +43,9 @@ router.delete('/package/:id', deletePackage);
 router.patch('/package', updatePackage);
 router.patch('/package/service/add', addPkgService);
 router.patch('/package/service/delete', removePkgService); 
+//
+
+// Patients
+router.patch('/inpatient/undo', undoInpatient);
 //
 export default router;

--- a/routes/ManagerRouter.js
+++ b/routes/ManagerRouter.js
@@ -14,6 +14,7 @@ import updatePackage from "../controllers/Manager/packageManagement/updatePackag
 import addPkgService from '../controllers/Manager/packageManagement/addPkgService.js';
 import removePkgService from "../controllers/Manager/packageManagement/removePkgService.js";
 import updateDoctor from "../controllers/Manager/doctorManagement/updateDoctor.js"; 
+import updateAdmin from "../controllers/Manager/adminManagement/updateAdmin.js";
 import undoInpatient from "../controllers/Manager/patientManagement/undoInpatient.js";
 const router = express.Router(); 
 
@@ -22,6 +23,7 @@ router.post('/admins', createAdmin);
 router.delete('/admins/:id', deleteAdmin); 
 router.get('/admins', getAllAdmins);
 router.get('/admins/search', searchAdmin); 
+router.patch('/admins/', updateAdmin);
 // 
 
 

--- a/routes/PublicRouter.js
+++ b/routes/PublicRouter.js
@@ -12,6 +12,7 @@ import getDoctors from "../controllers/Public/Doctors/getDoctors.js";
 import getPayments from "../controllers/Public/Payments/getPayments.js";
 import getSinglePayment from "../controllers/Public/Payments/getSinglePayment.js";
 import getActiveInpatient from "../controllers/Public/Patients/getActiveInpatient.js";
+import getRecordDiagnosis from "../controllers/Public/MedicalRecords/getRecordDiagnosis.js";
 const router = express.Router(); 
 
 // Patients 
@@ -29,6 +30,7 @@ router.get("/services/single/:id", getSingleService);
 // Medical records
 router.get("/medicalrecords", getMedicalRecords);
 router.get("/medicalrecords/single/:id", getSingleRecord); // id of the medical record
+router.get("/medicalrecords/diagnosis/:id", getRecordDiagnosis);
 //
 
 // Doctors 

--- a/utils/getUnixTodayInterval.js
+++ b/utils/getUnixTodayInterval.js
@@ -1,0 +1,13 @@
+const getInterval = () => {
+  const startOfToday = new Date();
+  const endOfToday = new Date();
+  startOfToday.setHours(0, 0, 0, 0);  
+  endOfToday.setHours(23, 59, 59, 999);  
+
+  const start = Math.floor(startOfToday.getTime());
+  const end = Math.floor(endOfToday.getTime());
+
+  return {start, end}
+}
+
+export default getInterval;


### PR DESCRIPTION
**Added**
- Ability for managers to "delete" (in fact just update fields to zero values) inpatients service
- From now only 1 active static field is available at a time (you cannot override static service)
- PATCH request for editing admins by managers
- mainDiagnosis field for Med Records
- PATCH / GET requests for diagnosis field of Med records

**Changed**
- Querries for doctor has been changed. Now doctors receive only inpatients with non-expired date and non deleted package, since they can do nothing with them
- Fixed `refreshToken.js` 
- Default behavior for doctors and admins queue GET reqs
- Changed patient's dateOfBirth type to Number
- Structure of PatientMedicalRecord model (added diagnosis)